### PR TITLE
[Feat] 사진 자세히 보기 컴포넌트에 닫기 버튼 인터랙션을 추가한다.

### DIFF
--- a/src/assets/svgs/BtnWritingChipx56.tsx
+++ b/src/assets/svgs/BtnWritingChipx56.tsx
@@ -1,13 +1,14 @@
 import type { SVGProps } from 'react';
 
-const SvgBtnWritingChipx56 = (props: SVGProps<SVGSVGElement>) => (
+const SvgBtnWritingChipx56 = ({ stroke = '#fff', ...props }: SVGProps<SVGSVGElement> & { stroke?: string }) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={56} height={56} fill="none" {...props}>
     <path
-      stroke="#fff"
+      stroke={stroke}
       strokeLinecap="round"
       strokeWidth={4.295}
       d="M40.444 15.555 15.555 40.444M40.444 40.443 15.556 15.555"
     />
   </svg>
 );
+
 export default SvgBtnWritingChipx56;

--- a/src/components/common/imgDetail/ImgDetail.styled.ts
+++ b/src/components/common/imgDetail/ImgDetail.styled.ts
@@ -22,13 +22,14 @@ export const ModalInnerWrapper = styled.div`
   margin-left: -10rem;
 `;
 
-export const CloseBtn = styled(BtnWritingChipx56)<{ strokeColor?: string }>`
+export const CloseBtn = styled(BtnWritingChipx56)`
   position: absolute;
   top: 2.4rem;
   right: 2.4rem;
   width: 5.6rem;
   height: 5.6rem;
 
+  background: transparent;
   border-radius: 12px;
 
   transition:
@@ -36,18 +37,24 @@ export const CloseBtn = styled(BtnWritingChipx56)<{ strokeColor?: string }>`
     transform 0.1s ease,
     opacity 0.2s ease;
 
-  stroke: ${({ strokeColor, theme }) => strokeColor || theme.colors.white1};
-
   &:hover {
     background-color: ${({ theme }) => theme.colors.gray4};
+  }
 
+  path {
+    stroke: ${({ theme }) => theme.colors.white1};
+  }
+
+  &:hover path {
     stroke: ${({ theme }) => theme.colors.gray6};
   }
 
   &:active {
     background: ${({ theme }) => theme.colors.gray4};
     transform: scale(0.95);
+  }
 
+  &:active path {
     stroke: ${({ theme }) => theme.colors.gray2};
   }
 `;

--- a/src/components/common/imgDetail/ImgDetail.styled.ts
+++ b/src/components/common/imgDetail/ImgDetail.styled.ts
@@ -22,10 +22,34 @@ export const ModalInnerWrapper = styled.div`
   margin-left: -10rem;
 `;
 
-export const CloseBtn = styled(BtnWritingChipx56)`
+export const CloseBtn = styled(BtnWritingChipx56)<{ strokeColor?: string }>`
   position: absolute;
   top: 2.4rem;
   right: 2.4rem;
+  width: 5.6rem;
+  height: 5.6rem;
+
+  border-radius: 12px;
+
+  transition:
+    background 0.2s ease,
+    transform 0.1s ease,
+    opacity 0.2s ease;
+
+  stroke: ${({ strokeColor, theme }) => strokeColor || theme.colors.white1};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray4};
+
+    stroke: ${({ theme }) => theme.colors.gray6};
+  }
+
+  &:active {
+    background: ${({ theme }) => theme.colors.gray4};
+    transform: scale(0.95);
+
+    stroke: ${({ theme }) => theme.colors.gray2};
+  }
 `;
 
 export const ImgThumb = styled.ul`

--- a/src/components/common/imgDetail/ImgDetail.tsx
+++ b/src/components/common/imgDetail/ImgDetail.tsx
@@ -12,7 +12,7 @@ const ImgDetail = ({ handleModalClose, imgList, index }: ImgDetailPropsType) => 
   const [activeIndex, setActiveIndex] = useState(index);
   return (
     <S.ModalOverlay>
-      <S.CloseBtn onClick={handleModalClose} />
+      <S.CloseBtn onClick={handleModalClose} strokeColor="white" />
       <S.ModalInnerWrapper>
         <S.ImgThumb>
           {imgList?.map((img, index) => (


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

### 📑 이슈 번호

<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #190 

<br>

### ✨️ 작업 내용

공통 컴포넌트인 ImgDetail의 CloseBtn 스타일을 조정해서 닫기 버튼에 인터랙션을 추가했습니다.
default 상태 / hover 상태 / click(press) - 누르고 있을 때 상태
3가지 상태로 구분했습니다.

<br>

### 💙 코멘트

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

<br>

### 📸 구현 결과

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

https://github.com/user-attachments/assets/36dc1229-d95a-4c8c-95e7-f70316d5e9cd


<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
