### PR TITLE
[Fix] 비회원의 경우, 커뮤니티 글쓰기 url 접근을 막는다

### DIFF
--- a/src/components/common/button/circleButton/CircleButton.styled.ts
+++ b/src/components/common/button/circleButton/CircleButton.styled.ts
@@ -5,6 +5,7 @@ export const ButtonWrapper = styled.button<{
   shadow: boolean;
   $whiteBtn: boolean;
   size: 'large' | 'medium' | 'small' | 'mini';
+  $disabled: boolean; //클릭은 반응하지만, 결과적으로 작동하지 않는 버튼
 }>`
   display: flex;
   align-items: center;
@@ -57,13 +58,20 @@ export const ButtonWrapper = styled.button<{
   &:hover {
     color: ${({ theme, $whiteBtn }) => $whiteBtn && theme.colors.white1};
 
-    background-color: ${({ theme }) => theme.colors.iris1_hover};
-    box-shadow: 0 0 12px 0 ${({ theme, $whiteBtn }) => $whiteBtn && theme.colors.shadow1};
+    background-color: ${({ theme, $disabled }) => !$disabled && theme.colors.iris1_hover};
+    box-shadow: 0 0 12px 0 ${({ theme, $whiteBtn, $disabled }) => !$disabled && $whiteBtn && theme.colors.shadow1};
   }
 
   &:active {
-    background-color: ${({ theme }) => theme.colors.iris1_click};
+    background-color: ${({ theme, $disabled }) => !$disabled && theme.colors.iris1_click};
   }
+
+  ${({ $disabled, theme }) =>
+    $disabled &&
+    `
+    color: ${theme.colors.gray4};
+    background-color: ${theme.colors.gray2};
+  `}
 
   &:disabled {
     color: ${({ theme }) => theme.colors.gray4};

--- a/src/components/common/button/circleButton/CircleButton.tsx
+++ b/src/components/common/button/circleButton/CircleButton.tsx
@@ -8,6 +8,7 @@ type ButtonProps = {
   shadow?: boolean;
   size?: 'large' | 'medium' | 'small' | 'mini';
   whiteBtn?: boolean;
+  $disabled?: boolean;
   handleClick?: () => void;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
@@ -18,6 +19,7 @@ const CircleButton = ({
   size = 'large',
   whiteBtn = false,
   handleClick,
+  $disabled,
   ...props
 }: ButtonProps) => {
   return (
@@ -26,6 +28,7 @@ const CircleButton = ({
       size={size}
       disabled={props.disabled}
       $whiteBtn={whiteBtn}
+      $disabled={$disabled || false}
       onClick={handleClick}
       {...props}
     >

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -4,6 +4,8 @@ import CircleButton from '@components/button/circleButton/CircleButton';
 import Loading from '@components/lottie/Loading';
 import Spacing from '@components/spacing/Spacing';
 import Title from '@components/title/Title';
+import Toast from '@components/toast/Toast';
+import { useToastOpen } from '@pages/CommunityDetail/hooks';
 import { handleScrollUp } from '@utils';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
@@ -22,6 +24,9 @@ const Community = () => {
   const navigate = useNavigate();
   const { data, fetchNextPage, hasNextPage, isLoading } = usePostListQuery(pickedtool, noTopic);
   const { ref, inView } = useInView();
+
+  const { isToastOpen, handleModalOpen } = useToastOpen();
+  const user = localStorage.getItem('user');
 
   const postList = data?.pages.map((item) => item.contents).flat();
 
@@ -74,23 +79,28 @@ const Community = () => {
         <S.FollowingBtns>
           <CircleButton
             onClick={() => {
-              const user = localStorage.getItem('user');
               if (user) {
                 navigate(`/community/write`);
+              } else {
+                handleModalOpen();
               }
             }}
             size="small"
             shadow
             icon={<IcPlusWhite20 />}
-            disabled={!localStorage.getItem('user')}
+            $disabled={!user}
           >
             글쓰기
           </CircleButton>
-
           <S.TopBtn type="button" onClick={handleScrollUp}>
             <IcChevron />
           </S.TopBtn>
         </S.FollowingBtns>
+        {isToastOpen && (
+          <Toast isVisible={isToastOpen} isWarning>
+            로그인 후 이용할 수 있습니다.
+          </Toast>
+        )}
       </S.CommunityWrapper>
     </>
   );

--- a/src/pages/communityWrite/CommunityWrite.tsx
+++ b/src/pages/communityWrite/CommunityWrite.tsx
@@ -1,10 +1,13 @@
+import ImgPopupl84 from '@assets/svgs/ImgPopupLogout84';
 import ToolListBanner from '@components/banner/ToolListBanner';
 import CircleButton from '@components/button/circleButton/CircleButton';
+import { AlterModal } from '@components/modal';
 import Title from '@components/title/Title';
 import Toast from '@components/toast/Toast';
+import { useModal } from '@pages/community/hooks';
 import { MYPAGE_QUERY_KEY } from '@pages/myPage/apis/queries';
 import { useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import postBoard from './apis/PostApi';
@@ -32,7 +35,16 @@ const CommunityWrite = () => {
   const navigate = useNavigate();
   const [isToastVisible, setIsToastVisible] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
+  const { isOpen, handleModal } = useModal();
   const queryClient = useQueryClient();
+
+  const user = localStorage.getItem('user');
+
+  useEffect(() => {
+    if (!user) {
+      handleModal('guest');
+    }
+  }, [user]);
 
   const handlePostSubmit = async () => {
     if (isButtonDisabled) return;
@@ -81,6 +93,20 @@ const CommunityWrite = () => {
             </Toast>
           </S.ToastBox>
         )}
+        <AlterModal
+          modalTitle="로그인 후 이용해주세요"
+          isOpen={isOpen}
+          handleClose={() => navigate(-1)}
+          isSingleModal={false}
+          ImgPopupModal={ImgPopupl84}
+          modalContent="글쓰기 페이지는 다루다의 회원만 접속할 수 있어요"
+          DoublebtnProps={{
+            isPrimaryRight: false,
+            primaryBtnContent: '로그인할게요',
+            secondaryBtnContent: '나중에할게요',
+            handleSecondClose: () => navigate('/login'),
+          }}
+        />
       </S.WriteWrapper>
     </>
   );


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

### 📑 이슈 번호

<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #184

<br>

### ✨️ 작업 내용
비회원의 경우, 글작성 페이지의 url 접근이 불가능하도록 설정합니다. 
페이지 도달시, 경고 모달과 함께 로그인 독려 모달을 띄웁니다.

추가로 3월 17일 회의 이후, 글쓰기 페이지를 disabled 처리하는 대신 비회원일 경우 toast 메시지가 뜰 수 있도록 변경한 코드를 반영했습니다.

<!-- 작업 내용을 간략히 설명해주세요 -->

<br>

### 💙 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

CircleBtn 에 대한 고민 

```ts
    <S.ButtonWrapper
      shadow={shadow}
      size={size}
      disabled={props.disabled}
      $whiteBtn={whiteBtn}
      $disabled={$disabled || false}
      onClick={handleClick}
      {...props}
    >
      {icon && <S.IconWrapper>{icon}</S.IconWrapper>}
      <span>{children}</span>
    </S.ButtonWrapper>
```

현재 위와 같이 $disable 과 disable 속성이 함께 있는 상태입니다. 

통일하지 않은 이유 
1)    `disabled={props.disabled}` 를 없앨 경우, 다른 페이지에서 사용되는 버튼에 있어서 버튼이 작동하지 않는 비활성화 기능이 무너지기 때문에 남겨두었습니다. 

2)       $disabled={$disabled || false} 를 추가한 이유, active( 버튼을 눌렀을떄)와 hover 상태일때에 대한 분기처리를 주기 위해서 + 회색 스타일을 적용하기 위해서 추가했습니다. 

코드 작성에 조금 아쉬움이 남아서 글을 작성해봅니다! 혹시 더 좋은 아이디어가 있으시다면 마구마구 던져주시면 감사합니다! 

<br>

### 📸 구현 결과

https://github.com/user-attachments/assets/089f06ef-32e0-4228-8f1d-d8095f232f76



<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
